### PR TITLE
Refine login flow and dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Using Mock Services
+
+The `src/services` directory contains mock implementations so you can try the frontend without a running backend. Set the following flag in your `.env.local` file:
+
+```bash
+NEXT_PUBLIC_USE_MOCK_DATA=true
+```
+
+When this flag is present the app loads the mock service modules. Removing it (or setting it to `false`) automatically switches to the real Supabase-based services under `src/services/*.ts`.
+
+## Frontend Architecture
+
+For a detailed overview of the recommended folder structure and design guidelines, see [docs/frontend-architecture.md](docs/frontend-architecture.md). The document covers component organization, navigation flow and how to extend the service layer when connecting a real backend.
+
 ## Deployment
 
 This application is ready to be deployed to [Vercel](https://vercel.com/).

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -1,0 +1,151 @@
+# Surplus Connect Frontend Architecture
+
+This document describes the recommended folder structure and key design principles for a production-ready Surplus Connect frontend built with **Next.js 14**, **TypeScript**, **Tailwind CSS**, and **shadcn/ui**.
+
+## Folder Structure
+
+```
+src/
+├─ app/                # Next.js app router pages and routes
+│  ├─ (auth)/          # Login/signup/reset flows
+│  ├─ dashboard/       # User, vendor and NGO dashboards
+│  ├─ contact/         # Contact form page
+│  └─ ...              # Additional pages (about, pricing, map)
+├─ components/
+│  ├─ ui/              # Reusable UI components from shadcn
+│  ├─ shared/          # Navbar, Footer, Map, ThemeToggle
+│  └─ dashboard/       # Dashboard specific widgets and forms
+├─ lib/                # Helper libraries (Supabase client, utilities)
+├─ services/           # Data fetching logic.  Automatically switches
+│                       between `*.mock.ts` and real implementations
+│                       based on `NEXT_PUBLIC_USE_MOCK_DATA` flag.
+├─ types/              # Generated database and shared types
+└─ data/               # Mock data used by tests or demos
+```
+
+## Component Guidelines
+
+- **Mobile First & Responsive**: All components should use fluid layouts (`flex`, `grid`) and Tailwind breakpoints.
+- **Accessibility**: Provide labels, use semantic HTML and ARIA attributes. Keyboard navigation must be tested.
+- **Dark Mode**: `next-themes` handles theme switching. Tailwind's `dark:` variants define styles.
+- **Reusability**: Build small components (e.g. `Button`, `Card`, `Modal`) under `components/ui` and compose them in pages.
+
+## Navigation Flow
+
+1. **Home** – Mission statement and call to action.
+2. **Auth** – Register or login. Demo users are pre-populated for quick testing.
+3. **Dashboard** – Loaded based on the user role (`vendor`, `consumer`, `ngo`).
+   - Vendors manage listings and view analytics.
+   - Consumers/NGOs browse reservations and see stats.
+4. **Map** – Interactive map of available listings. Users can reserve items.
+5. **Contact** – Simple form that posts to `/api/contact`.
+
+The `Navbar` shows relevant links once a user is logged in and adapts for mobile using a Radix UI `Sheet`.
+
+## Extension Points
+
+- **Services**: Each file in `src/services` exports typed functions. When ready to connect a real backend, implement the matching functions in `*.ts` and remove the `NEXT_PUBLIC_USE_MOCK_DATA` flag.
+- **Analytics**: `analyticsService.*` demonstrates how events could be tracked.
+- **Payments**: Future Stripe integration can live under `src/services/paymentService.ts`.
+
+## Example: Listing Service (Mock)
+
+```ts
+// src/services/listingService.mock.ts
+import { Database } from '@/types/database.types'
+export type Listing = Database['public']['Tables']['listings']['Row']
+
+let listings: Listing[] = [
+  {
+    id: 1,
+    vendor_id: 'vendor1',
+    name: 'Leftover Pizza Slices',
+    description: "Assorted slices from today's batches.",
+    quantity: '8',
+    expiry_time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+    pickup_window_start: new Date().toISOString(),
+    pickup_window_end: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+    image_url: null,
+    location: 'POINT(77.5946 12.9716)',
+    status: 'available',
+    created_at: new Date().toISOString(),
+  },
+]
+
+export async function fetchAvailableListings() {
+  return listings
+}
+```
+
+Real implementations live in `listingService.ts` and talk to Supabase. The loader in `src/services/index.ts` exports either version at runtime.
+
+## Keeping Code DRY and Testable
+
+- Centralise API calls in the `services` directory.
+- Use React hooks (`useEffect`, `useState`) only in components and keep them lean.
+- Type all data structures with the generated database types.
+- Mock services return promises to simulate async behaviour, enabling frontend unit tests with tools like React Testing Library.
+
+## UI/UX Libraries Used
+
+- **Next.js** – App Router for file based routing and server components.
+- **Tailwind CSS** – Utility-first styling with design tokens.
+- **shadcn/ui** – Accessible React components built on Radix UI.
+- **React Leaflet** – Map rendering over OpenStreetMap tiles.
+- **next-themes** – Light/dark mode with system preference detection.
+- **Supabase JS** – Browser client for authentication and database access.
+
+These tools keep the codebase minimal yet powerful, allowing quick iteration and consistent design across the application.
+
+## Example: Listing Card Component
+
+```tsx
+// src/components/shared/ListingCard.tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+
+export interface ListingCardProps {
+  title: string
+  quantity: number
+  status: 'available' | 'reserved' | 'collected'
+  onReserve?: () => void
+}
+
+export default function ListingCard({ title, quantity, status, onReserve }: ListingCardProps) {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle className="text-lg">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">Quantity: {quantity}</p>
+        <Badge variant={status === 'available' ? 'default' : status === 'reserved' ? 'secondary' : 'outline'}>
+          {status}
+        </Badge>
+        {status === 'available' && onReserve && (
+          <button onClick={onReserve} className="w-full mt-4 bg-primary text-primary-foreground py-1 rounded">
+            Reserve
+          </button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+## Navigation by User Role
+
+1. **Vendors** – After login they see `/dashboard` with the vendor dashboard. Here they can add listings, edit them and monitor reservations.
+2. **Consumers & NGOs** – Login redirects to the same `/dashboard` route but loads the consumer/NGO dashboard showing reservations and a link to the map.
+3. **Admins** – Redirected to `/admin` where moderation tools and analytics would live.
+
+The main `Navbar` detects the role from the user profile (stored in Supabase or mock storage) and only shows links relevant to that role.
+
+## Keeping Things Scalable
+
+- Reuse UI components from `src/components/ui` and extend them when needed.
+- Keep business logic in the `services` layer so pages remain focused on rendering.
+- Use environment variables like `NEXT_PUBLIC_USE_MOCK_DATA` to switch between mock data and real APIs without code changes.
+- Type everything with the generated database types to avoid runtime errors and enable IDE autocomplete.
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "eslint-config-next": "15.4.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5"
+        "typescript": "^5",
+        "typescript-eslint": "^8.37.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6898,6 +6899,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.37.0.tgz",
+      "integrity": "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.37.0",
+        "@typescript-eslint/parser": "8.37.0",
+        "@typescript-eslint/typescript-estree": "8.37.0",
+        "@typescript-eslint/utils": "8.37.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-next": "15.4.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "typescript-eslint": "^8.37.0"
   }
 }

--- a/schema.sql
+++ b/schema.sql
@@ -67,6 +67,15 @@ CREATE TABLE IF NOT EXISTS public.analytics (
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- CONTACT MESSAGES TABLE
+CREATE TABLE IF NOT EXISTS public.contact_messages (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  message TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
 -- ENABLE RLS
 ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.listings ENABLE ROW LEVEL SECURITY;
@@ -74,6 +83,7 @@ ALTER TABLE public.reservations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.analytics ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.badges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contact_messages ENABLE ROW LEVEL SECURITY;
 
 -- RLS POLICIES (same as your original, with extra for notifications/analytics)
 -- Add as needed (for brevity, reuse your policies, add these as examples):
@@ -89,6 +99,10 @@ CREATE POLICY "Users can view their own analytics."
 -- Badges: Anyone can read badges (for displaying them in UI)
 CREATE POLICY "Badges are viewable by everyone."
   ON public.badges FOR SELECT USING (true);
+
+-- Contact messages: anyone can submit
+CREATE POLICY "Anyone can submit contact messages"
+  ON public.contact_messages FOR INSERT WITH CHECK (true);
 
 -- Automated Badge Assignment Logic
 CREATE OR REPLACE FUNCTION public.assign_badge()

--- a/src/app/(auth)/auth-form.tsx
+++ b/src/app/(auth)/auth-form.tsx
@@ -4,6 +4,7 @@
 const DEMO_USERS = [
   { email: 'user@example.com', password: 'userpass', role: 'user', name: 'Demo User' },
   { email: 'vendor@example.com', password: 'vendorpass', role: 'vendor', name: 'Demo Vendor' },
+  { email: 'ngo@example.com', password: 'ngopass', role: 'ngo', name: 'Demo NGO' },
   { email: 'admin@example.com', password: 'adminpass', role: 'admin', name: 'Demo Admin' },
 ];
 
@@ -260,6 +261,7 @@ export default function AuthForm({ view }: AuthFormProps) {
                 Demo accounts:<br />
                 user@example.com / userpass<br />
                 vendor@example.com / vendorpass<br />
+                ngo@example.com / ngopass<br />
                 admin@example.com / adminpass
               </p>
             )}

--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -15,6 +15,7 @@ import { createClient } from "@/lib/supabase/client";
 const DEMO_USERS = [
   { email: 'user@example.com', password: 'userpass', role: 'user', name: 'Demo User' },
   { email: 'vendor@example.com', password: 'vendorpass', role: 'vendor', name: 'Demo Vendor' },
+  { email: 'ngo@example.com', password: 'ngopass', role: 'ngo', name: 'Demo NGO' },
   { email: 'admin@example.com', password: 'adminpass', role: 'admin', name: 'Demo Admin' },
 ];
 
@@ -128,6 +129,7 @@ export default function LoginForm() {
               Demo accounts:<br />
               user@example.com / userpass<br />
               vendor@example.com / vendorpass<br />
+              ngo@example.com / ngopass<br />
               admin@example.com / adminpass
             </p>
           </form>

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -274,6 +274,7 @@ export default function SignupForm() {
                 Demo accounts:<br />
                 user@example.com / userpass<br />
                 vendor@example.com / vendorpass<br />
+                ngo@example.com / ngopass<br />
                 admin@example.com / adminpass
               </p>
             </form>

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { createServer } from '@/lib/supabase/server';
+
+export async function POST(request: Request) {
+  const { name, email, message } = await request.json();
+
+  if (!name || !email || !message) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  }
+
+  const supabase = await createServer();
+  const { error } = await supabase
+    .from('contact_messages')
+    .insert({ name, email, message });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,29 +1,95 @@
-import React from 'react';
+"use client";
+
+import { FormEvent, useState } from "react";
 
 export default function ContactPage() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setStatus("loading");
+    setError(null);
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, message }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to send message");
+      }
+      setStatus("success");
+      setName("");
+      setEmail("");
+      setMessage("");
+    } catch (err: any) {
+      setStatus("error");
+      setError(err.message);
+    }
+  };
+
   return (
     <div className="container mx-auto py-16 px-4 sm:px-6 lg:px-8 max-w-xl">
       <h1 className="text-4xl font-extrabold mb-6 text-center">Contact Us</h1>
       <p className="text-lg text-muted-foreground mb-8 text-center">
         Have questions, feedback, or want to partner with us? Fill out the form below or email us at <a href="mailto:hello@surplusconnect.org" className="text-primary underline">hello@surplusconnect.org</a>.
       </p>
-      <form className="space-y-6 bg-card p-6 rounded-lg shadow-md">
+      {status === "success" && (
+        <p className="text-center text-primary mb-4">Thanks for reaching out! We'll get back to you soon.</p>
+      )}
+      {status === "error" && error && (
+        <p className="text-center text-destructive mb-4">{error}</p>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-6 bg-card p-6 rounded-lg shadow-md">
         <div>
           <label htmlFor="name" className="block font-medium mb-1">Name</label>
-          <input id="name" type="text" className="w-full border border-border rounded px-3 py-2 bg-background" placeholder="Your Name" />
+          <input
+            id="name"
+            type="text"
+            className="w-full border border-border rounded px-3 py-2 bg-background"
+            placeholder="Your Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
         </div>
         <div>
           <label htmlFor="email" className="block font-medium mb-1">Email</label>
-          <input id="email" type="email" className="w-full border border-border rounded px-3 py-2 bg-background" placeholder="you@email.com" />
+          <input
+            id="email"
+            type="email"
+            className="w-full border border-border rounded px-3 py-2 bg-background"
+            placeholder="you@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
         </div>
         <div>
           <label htmlFor="message" className="block font-medium mb-1">Message</label>
-          <textarea id="message" className="w-full border border-border rounded px-3 py-2 bg-background" rows={4} placeholder="How can we help?" />
+          <textarea
+            id="message"
+            className="w-full border border-border rounded px-3 py-2 bg-background"
+            rows={4}
+            placeholder="How can we help?"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            required
+          />
         </div>
-        <button type="submit" className="w-full bg-primary text-primary-foreground py-2 rounded font-semibold shadow hover:bg-primary/90 transition-colors" disabled>
-          Send Message (Coming Soon)
+        <button
+          type="submit"
+          className="w-full bg-primary text-primary-foreground py-2 rounded font-semibold shadow hover:bg-primary/90 transition-colors"
+          disabled={status === "loading"}
+        >
+          {status === "loading" ? "Sending..." : "Send Message"}
         </button>
       </form>
     </div>
   );
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,194 +1,26 @@
-'use client';
+'use client'
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { Button } from "@/components/ui/Button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ArrowRight, MapPin, ShoppingCart, Users, Award, Leaf } from "lucide-react";
-import Link from "next/link";
-
-const pricingData = [
-  {
-    type: "Vendor",
-    color: "bg-primary/10 border-primary",
-    icon: <ShoppingCart className="h-8 w-8 text-primary" />,
-    perUse: "₹10/listing",
-    oneDay: "₹149 (all day)",
-    thirtyDay: "₹999 (month)",
-    desc: "For restaurants, grocers, and caterers to list surplus food.",
-  },
-  {
-    type: "NGO",
-    color: "bg-green-100 border-green-500",
-    icon: <Award className="h-8 w-8 text-green-600" />,
-    perUse: "₹5/claim*",
-    oneDay: "₹99 (all day)",
-    thirtyDay: "₹499 (month)",
-    desc: "For NGOs to claim and distribute food to those in need.",
-  },
-  {
-    type: "User",
-    color: "bg-blue-100 border-blue-500",
-    icon: <Users className="h-8 w-8 text-blue-600" />,
-    perUse: "₹5/claim",
-    oneDay: "₹49 (all day)",
-    thirtyDay: "₹149 (month)",
-    desc: "For individuals to claim surplus food and reduce waste.",
-  },
-];
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import LoginForm from './(auth)/login/LoginForm'
 
 export default function Home() {
-  const router = useRouter();
-  const [role, setRole] = useState<string | null>(null);
+  const router = useRouter()
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const user = localStorage.getItem('demoUser');
-      if (user) {
-        const parsed = JSON.parse(user);
-        setRole(parsed.role);
-        if (parsed.role === 'admin') router.replace('/admin');
-        else router.replace('/dashboard');
-      }
+    const stored = localStorage.getItem('demoUser')
+    if (stored) {
+      const { role } = JSON.parse(stored)
+      router.replace(role === 'admin' ? '/admin' : '/dashboard')
     }
-  }, [router]);
-
-  // Pricing logic removed from homepage
+  }, [router])
 
   return (
-    <div className="flex flex-col">
-      {/* Hero Section */}
-      <section className="w-full bg-background">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-col items-center justify-center py-20 md:py-28 text-center space-y-8 max-w-3xl mx-auto">
-            <h1 className="text-5xl md:text-6xl font-extrabold text-foreground tracking-tight leading-tight">
-              Save Food. Feed People. <span className="text-primary">Reduce Waste.</span>
-            </h1>
-            <p className="text-xl text-muted-foreground max-w-xl mx-auto">
-              Surplus Connect is a non-profit platform dedicated to fighting food waste by connecting food vendors with people and NGOs in need. Join us and make a real impact in your community.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button size="lg" asChild>
-                <Link href="/map">Find Food Near You <ArrowRight className="ml-2 h-5 w-5" /></Link>
-              </Button>
-              <Button size="lg" variant="outline" asChild>
-                <Link href="/signup?role=vendor">Become a Vendor</Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Impact Stats Section */}
-      <section className="w-full py-16 bg-secondary/60">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid gap-8 md:grid-cols-3">
-            <Card className="text-center border-0 shadow-lg">
-              <CardHeader>
-                <div className="mx-auto bg-primary text-primary-foreground rounded-full h-16 w-16 flex items-center justify-center">
-                  <Users className="h-8 w-8" />
-                </div>
-                <CardTitle className="mt-4 text-xl">10,000+ Meals Saved</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">Every meal rescued is a step toward a more sustainable world.</p>
-              </CardContent>
-            </Card>
-            <Card className="text-center border-0 shadow-lg">
-              <CardHeader>
-                <div className="mx-auto bg-primary text-primary-foreground rounded-full h-16 w-16 flex items-center justify-center">
-                  <Leaf className="h-8 w-8" />
-                </div>
-                <CardTitle className="mt-4 text-xl">25,000+ kg CO₂ Diverted</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">Reducing food waste means less greenhouse gas emissions.</p>
-              </CardContent>
-            </Card>
-            <Card className="text-center border-0 shadow-lg">
-              <CardHeader>
-                <div className="mx-auto bg-primary text-primary-foreground rounded-full h-16 w-16 flex items-center justify-center">
-                  <Award className="h-8 w-8" />
-                </div>
-                <CardTitle className="mt-4 text-xl">Community Champions</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">Join our growing network of vendors, NGOs, and volunteers.</p>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </section>
-
-      {/* How It Works Section */}
-      <section className="w-full py-20 bg-background">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl md:text-4xl font-bold">How It Works</h2>
-            <p className="text-muted-foreground mt-2 max-w-2xl mx-auto">A simple three-step process to rescue food and build a stronger community.</p>
-          </div>
-          <div className="grid md:grid-cols-3 gap-8">
-            <Card className="text-center border-0 shadow-lg">
-              <CardHeader>
-                <div className="mx-auto bg-primary text-primary-foreground rounded-full h-16 w-16 flex items-center justify-center">
-                  <ShoppingCart className="h-8 w-8" />
-                </div>
-                <CardTitle className="mt-4 text-xl">1. Vendors List Surplus</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">
-                  Restaurants, grocers, and caterers post their unsold, surplus food items on our platform quickly and easily.
-                </p>
-              </CardContent>
-            </Card>
-            <Card className="text-center border-0 shadow-lg">
-              <CardHeader>
-                <div className="mx-auto bg-primary text-primary-foreground rounded-full h-16 w-16 flex items-center justify-center">
-                  <MapPin className="h-8 w-8" />
-                </div>
-                <CardTitle className="mt-4 text-xl">2. Users Find & Reserve</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">
-                  Individuals and NGOs browse the map, find available food nearby, and reserve it for pickup with a single click.
-                </p>
-              </CardContent>
-            </Card>
-            <Card className="text-center border-0 shadow-lg">
-              <CardHeader>
-                <div className="mx-auto bg-primary text-primary-foreground rounded-full h-16 w-16 flex items-center justify-center">
-                  <Users className="h-8 w-8" />
-                </div>
-                <CardTitle className="mt-4 text-xl">3. Community Benefits</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">
-                  Food is saved from the landfill, people get fed, and we build a more sustainable community together.
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </section>
-
-      {/* Call to Action Section */}
-      <section className="w-full py-20 bg-secondary/80">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Ready to Make an Impact?
-          </h2>
-          <p className="text-muted-foreground max-w-3xl mx-auto mb-8">
-            Whether you're a business with surplus food or an individual looking to help, you can be a part of the solution. Sign up today and join the movement to end food waste.
-          </p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4">
-            <Button size="lg" asChild>
-              <Link href="/signup">Join as a User</Link>
-            </Button>
-            <Button size="lg" variant="secondary" asChild>
-              <Link href="/signup?role=vendor">Register Your Business</Link>
-            </Button>
-          </div>
-        </div>
-      </section>
+    <div className="container mx-auto flex flex-col items-center justify-center py-20 px-4 max-w-md">
+      <h1 className="text-4xl font-bold mb-6 text-center">Welcome to Surplus Connect</h1>
+      <p className="text-muted-foreground mb-6 text-center">
+        Sign in to access your dashboard and start rescuing food.
+      </p>
+      <LoginForm />
     </div>
-  );
+  )
 }

--- a/src/components/dashboard/NgoDashboard.tsx
+++ b/src/components/dashboard/NgoDashboard.tsx
@@ -1,0 +1,1 @@
+export { default } from './UserDashboard';

--- a/src/components/shared/ListingCard.tsx
+++ b/src/components/shared/ListingCard.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+
+export interface ListingCardProps {
+  title: string
+  quantity: number
+  status: 'available' | 'reserved' | 'collected'
+  onReserve?: () => void
+}
+
+export default function ListingCard({ title, quantity, status, onReserve }: ListingCardProps) {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle className="text-lg">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">Quantity: {quantity}</p>
+        <Badge variant={status === 'available' ? 'default' : status === 'reserved' ? 'secondary' : 'outline'}>
+          {status}
+        </Badge>
+        {status === 'available' && onReserve && (
+          <button onClick={onReserve} className="w-full mt-4 bg-primary text-primary-foreground py-1 rounded">
+            Reserve
+          </button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -37,14 +37,17 @@ export default function Navbar() {
 
   const closeSheet = () => setIsSheetOpen(false)
 
-  let navLinks = [
-    { href: '/', label: 'Home' },
-    { href: '/map', label: 'Map' },
-    { href: '/pricing', label: 'Pricing' },
-  ]
+  let navLinks = role
+    ? [{ href: '/map', label: 'Map' }]
+    : [
+        { href: '/', label: 'Home' },
+        { href: '/map', label: 'Map' },
+        { href: '/pricing', label: 'Pricing' },
+      ]
+
   if (role === 'admin') {
     navLinks.push({ href: '/admin', label: 'Admin' })
-  } else if (role === 'vendor' || role === 'user') {
+  } else if (role === 'vendor' || role === 'user' || role === 'ngo') {
     navLinks.push({ href: '/dashboard', label: 'Dashboard' })
   }
 

--- a/src/services/analyticsService.mock.ts
+++ b/src/services/analyticsService.mock.ts
@@ -1,0 +1,30 @@
+interface AnalyticsEvent {
+  id: number
+  user_id: string
+  event_type: string
+  meta: Record<string, any> | null
+  created_at: string
+}
+
+const events: AnalyticsEvent[] = [
+  { id: 1, user_id: 'vendor1', event_type: 'listing_created', meta: null, created_at: new Date().toISOString() },
+  { id: 2, user_id: 'user1', event_type: 'reservation_made', meta: null, created_at: new Date().toISOString() },
+]
+
+let nextId = 3
+
+function delay<T>(data: T, ms = 300): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(data), ms))
+}
+
+export async function fetchEvents(userId: string): Promise<AnalyticsEvent[]> {
+  return delay(events.filter((e) => e.user_id === userId))
+}
+
+export async function addEvent(userId: string, event_type: string, meta: Record<string, any> | null = null): Promise<AnalyticsEvent> {
+  const event: AnalyticsEvent = { id: nextId++, user_id: userId, event_type, meta, created_at: new Date().toISOString() }
+  events.push(event)
+  return delay(event)
+}
+
+export const _internal = { events }

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@/lib/supabase/client'
+import { AnalyticsEvent } from './analyticsService.mock'
+
+const supabase = createClient()
+
+export async function fetchEvents(userId: string) {
+  const { data, error } = await supabase
+    .from('analytics')
+    .select('*')
+    .eq('user_id', userId)
+  if (error) throw error
+  return data as AnalyticsEvent[]
+}
+
+export async function addEvent(userId: string, event_type: string, meta: Record<string, any> | null = null) {
+  const { data, error } = await supabase
+    .from('analytics')
+    .insert({ user_id: userId, event_type, meta })
+    .select()
+    .single()
+  if (error) throw error
+  return data as AnalyticsEvent
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,34 @@
+import * as listingMock from './listingService.mock'
+import * as listingReal from './listingService'
+import * as profileMock from './profileService.mock'
+import * as profileReal from './profileService'
+import * as reservationMock from './reservationService.mock'
+import * as reservationReal from './reservationService'
+import * as notificationMock from './notificationService.mock'
+import * as notificationReal from './notificationService'
+import * as analyticsMock from './analyticsService.mock'
+import * as analyticsReal from './analyticsService'
+
+const useMock = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true'
+
+export const {
+  fetchListingsForVendor,
+  fetchAvailableListings,
+  addListing,
+  updateListing,
+  deleteListing,
+} = useMock ? listingMock : listingReal
+
+export const { fetchProfile } = useMock ? profileMock : profileReal
+export const {
+  fetchReservationsForUser,
+  addReservation,
+} = useMock ? reservationMock : reservationReal
+export const {
+  fetchNotifications,
+  markAsRead,
+} = useMock ? notificationMock : notificationReal
+export const {
+  fetchEvents,
+  addEvent,
+} = useMock ? analyticsMock : analyticsReal

--- a/src/services/listingService.mock.ts
+++ b/src/services/listingService.mock.ts
@@ -1,0 +1,84 @@
+import { Database } from '@/types/database.types'
+
+export type Listing = Database['public']['Tables']['listings']['Row']
+
+interface NewListing extends Omit<Database['public']['Tables']['listings']['Insert'], 'id' | 'created_at'> {}
+interface UpdateListing extends Partial<NewListing> {}
+
+const sampleVendors = [
+  { id: 'vendor1', name: 'The Corner Cafe' },
+  { id: 'vendor2', name: 'Downtown Bakery' },
+]
+
+let listings: Listing[] = [
+  {
+    id: 1,
+    vendor_id: 'vendor1',
+    name: 'Leftover Pizza Slices',
+    description: 'Assorted slices from today\'s batches.',
+    quantity: '8',
+    expiry_time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+    pickup_window_start: new Date().toISOString(),
+    pickup_window_end: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+    image_url: null,
+    location: 'POINT(77.5946 12.9716)',
+    status: 'available',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    vendor_id: 'vendor2',
+    name: 'Veggie Soup Quarts',
+    description: 'Hearty vegetable soup ready for pickup.',
+    quantity: '5',
+    expiry_time: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(),
+    pickup_window_start: new Date().toISOString(),
+    pickup_window_end: new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString(),
+    image_url: null,
+    location: 'POINT(78.4867 17.3850)',
+    status: 'available',
+    created_at: new Date().toISOString(),
+  },
+]
+
+let nextId = 3
+
+function delay<T>(data: T, ms = 300): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(data), ms))
+}
+
+export async function fetchListingsForVendor(vendorId: string): Promise<Listing[]> {
+  return delay(listings.filter((l) => l.vendor_id === vendorId))
+}
+
+export async function fetchAvailableListings(): Promise<Listing[]> {
+  return delay(listings.filter((l) => l.status === 'available'))
+}
+
+export async function addListing(vendorId: string, data: NewListing): Promise<Listing> {
+  const listing: Listing = {
+    id: nextId++,
+    created_at: new Date().toISOString(),
+    vendor_id: vendorId,
+    status: 'available',
+    image_url: null,
+    ...data,
+  }
+  listings.push(listing)
+  return delay(listing)
+}
+
+export async function updateListing(id: number, updates: UpdateListing): Promise<Listing | null> {
+  const index = listings.findIndex((l) => l.id === id)
+  if (index === -1) return delay(null)
+  listings[index] = { ...listings[index], ...updates }
+  return delay(listings[index])
+}
+
+export async function deleteListing(id: number): Promise<boolean> {
+  const lengthBefore = listings.length
+  listings = listings.filter((l) => l.id !== id)
+  return delay(listings.length < lengthBefore)
+}
+
+export const _internal = { listings, sampleVendors }

--- a/src/services/listingService.ts
+++ b/src/services/listingService.ts
@@ -1,0 +1,49 @@
+import { createClient } from '@/lib/supabase/client'
+import { Listing, NewListing, UpdateListing } from './listingService.mock'
+
+const supabase = createClient()
+
+export async function fetchListingsForVendor(vendorId: string) {
+  const { data, error } = await supabase
+    .from('listings')
+    .select('*')
+    .eq('vendor_id', vendorId)
+  if (error) throw error
+  return data as Listing[]
+}
+
+export async function fetchAvailableListings() {
+  const { data, error } = await supabase
+    .from('listings')
+    .select('*')
+    .eq('status', 'available')
+  if (error) throw error
+  return data as Listing[]
+}
+
+export async function addListing(vendorId: string, data: NewListing) {
+  const { data: inserted, error } = await supabase
+    .from('listings')
+    .insert({ ...data, vendor_id: vendorId })
+    .select()
+    .single()
+  if (error) throw error
+  return inserted as Listing
+}
+
+export async function updateListing(id: number, updates: UpdateListing) {
+  const { data, error } = await supabase
+    .from('listings')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  return data as Listing
+}
+
+export async function deleteListing(id: number) {
+  const { error } = await supabase.from('listings').delete().eq('id', id)
+  if (error) throw error
+  return true
+}

--- a/src/services/notificationService.mock.ts
+++ b/src/services/notificationService.mock.ts
@@ -1,0 +1,25 @@
+import { Database } from '@/types/database.types'
+
+export type Notification = Database['public']['Tables']['notifications']['Row']
+
+let notifications: Notification[] = [
+  { id: 1, user_id: 'user1', type: 'listing', message: 'New listing near you', data: null, read: false, created_at: new Date().toISOString() },
+  { id: 2, user_id: 'vendor1', type: 'reservation', message: 'Your listing was reserved', data: null, read: false, created_at: new Date().toISOString() },
+]
+
+let nextId = 3
+
+function delay<T>(data: T, ms = 300): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(data), ms))
+}
+
+export async function fetchNotifications(userId: string): Promise<Notification[]> {
+  return delay(notifications.filter((n) => n.user_id === userId))
+}
+
+export async function markAsRead(id: number): Promise<void> {
+  notifications = notifications.map((n) => (n.id === id ? { ...n, read: true } : n))
+  return delay(undefined)
+}
+
+export const _internal = { notifications }

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@/lib/supabase/client'
+import { Notification } from './notificationService.mock'
+
+const supabase = createClient()
+
+export async function fetchNotifications(userId: string) {
+  const { data, error } = await supabase
+    .from('notifications')
+    .select('*')
+    .eq('user_id', userId)
+  if (error) throw error
+  return data as Notification[]
+}
+
+export async function markAsRead(id: number) {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ read: true })
+    .eq('id', id)
+  if (error) throw error
+}

--- a/src/services/profileService.mock.ts
+++ b/src/services/profileService.mock.ts
@@ -1,0 +1,21 @@
+import { Database } from '@/types/database.types'
+
+export type Profile = Database['public']['Tables']['profiles']['Row']
+
+const profiles: Profile[] = [
+  { id: 'vendor1', name: 'The Corner Cafe', role: 'vendor', meals_saved: 12, created_at: new Date().toISOString(), avatar_url: null },
+  { id: 'vendor2', name: 'Downtown Bakery', role: 'vendor', meals_saved: 5, created_at: new Date().toISOString(), avatar_url: null },
+  { id: 'user1', name: 'Jane Doe', role: 'user', meals_saved: 3, created_at: new Date().toISOString(), avatar_url: null },
+  { id: 'user2', name: 'John Smith', role: 'user', meals_saved: 1, created_at: new Date().toISOString(), avatar_url: null },
+  { id: 'ngo1', name: 'Helping Hands NGO', role: 'ngo', meals_saved: 20, created_at: new Date().toISOString(), avatar_url: null },
+]
+
+function delay<T>(data: T, ms = 300): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(data), ms))
+}
+
+export async function fetchProfile(id: string): Promise<Profile | null> {
+  return delay(profiles.find((p) => p.id === id) || null)
+}
+
+export const _internal = { profiles }

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@/lib/supabase/client'
+import { Profile } from './profileService.mock'
+
+const supabase = createClient()
+
+export async function fetchProfile(id: string) {
+  const { data, error } = await supabase.from('profiles').select('*').eq('id', id).single()
+  if (error) throw error
+  return data as Profile
+}

--- a/src/services/reservationService.mock.ts
+++ b/src/services/reservationService.mock.ts
@@ -1,0 +1,32 @@
+import { Database } from '@/types/database.types'
+
+export type Reservation = Database['public']['Tables']['reservations']['Row']
+
+let reservations: Reservation[] = [
+  { id: 1, listing_id: 1, consumer_id: 'user1', status: 'active', created_at: new Date().toISOString() },
+  { id: 2, listing_id: 2, consumer_id: 'ngo1', status: 'completed', created_at: new Date().toISOString() },
+]
+
+let nextId = 3
+
+function delay<T>(data: T, ms = 300): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(data), ms))
+}
+
+export async function fetchReservationsForUser(userId: string): Promise<Reservation[]> {
+  return delay(reservations.filter((r) => r.consumer_id === userId))
+}
+
+export async function addReservation(listingId: number, consumerId: string): Promise<Reservation> {
+  const reservation: Reservation = {
+    id: nextId++,
+    listing_id: listingId,
+    consumer_id: consumerId,
+    status: 'active',
+    created_at: new Date().toISOString(),
+  }
+  reservations.push(reservation)
+  return delay(reservation)
+}
+
+export const _internal = { reservations }

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@/lib/supabase/client'
+import { Reservation } from './reservationService.mock'
+
+const supabase = createClient()
+
+export async function fetchReservationsForUser(userId: string) {
+  const { data, error } = await supabase
+    .from('reservations')
+    .select('*')
+    .eq('consumer_id', userId)
+  if (error) throw error
+  return data as Reservation[]
+}
+
+export async function addReservation(listingId: number, consumerId: string) {
+  const { data, error } = await supabase
+    .from('reservations')
+    .insert({ listing_id: listingId, consumer_id: consumerId })
+    .select()
+    .single()
+  if (error) throw error
+  return data as Reservation
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -186,6 +186,29 @@ export interface Database {
           created_at?: string;
         };
       };
+      contact_messages: {
+        Row: {
+          id: number;
+          name: string;
+          email: string;
+          message: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: number;
+          name: string;
+          email: string;
+          message: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: number;
+          name?: string;
+          email?: string;
+          message?: string;
+          created_at?: string;
+        };
+      };
     };
     Views: {
       [_ in never]: never;


### PR DESCRIPTION
## Summary
- overhaul homepage to show login and auto-redirect when already signed in
- include NGO credentials on the sign-up page
- hide the Home link when logged in
- allow dashboard to read role from demo storage

## Testing
- `npm run lint` *(fails: many `React must be in scope` errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a47aa91fc832bbe90a55cf5e9b9e8